### PR TITLE
Add more parameters to mutation callbacks

### DIFF
--- a/query/gc-query.spec.ts
+++ b/query/gc-query.spec.ts
@@ -703,8 +703,9 @@ describe('GcQuery', () => {
       onMutate: onMutateFn,
     });
 
-    mutation.mutate(1);
-    expect(onMutateFn).toHaveBeenCalledWith(1);
+    const mockRequest = 1;
+    mutation.mutate(mockRequest);
+    expect(onMutateFn).toHaveBeenCalledWith([mockRequest]);
   });
 
   it('should call onSuccess callback function when mutating', () => {
@@ -714,8 +715,22 @@ describe('GcQuery', () => {
       onSuccess: onSuccessFn,
     });
 
-    mutation.mutate(1);
-    expect(onSuccessFn).toHaveBeenCalledWith(1);
+    const mockRequest = 1;
+    mutation.mutate(mockRequest);
+    expect(onSuccessFn).toHaveBeenCalledWith(1, [mockRequest], undefined);
+  });
+
+  it('should call onSuccess callback function with multiple args', () => {
+    const mutationFn = jest.fn((arg: number, arg2: string) => of(arg));
+    const onSuccessFn = jest.fn();
+    const mutation = useMutation(mutationFn, {
+      onSuccess: onSuccessFn,
+    });
+
+    const request: Parameters<typeof mutationFn> = [1, '2'];
+
+    mutation.mutate(...request);
+    expect(onSuccessFn).toHaveBeenCalledWith(1, request, undefined);
   });
 
   it('should call onError callback function when mutating', () => {
@@ -727,8 +742,9 @@ describe('GcQuery', () => {
       onError: onErrorFn,
     });
 
-    mutation.mutate(1);
-    expect(onErrorFn).toHaveBeenCalledWith(error, undefined);
+    const mockRequest = 1;
+    mutation.mutate(mockRequest);
+    expect(onErrorFn).toHaveBeenCalledWith(error, [mockRequest], undefined);
   });
 
   it('should call onError callback function with context when available and when mutating ', () => {
@@ -741,7 +757,8 @@ describe('GcQuery', () => {
       onMutate: () => 'context',
     });
 
-    mutation.mutate(1);
-    expect(onErrorFn).toHaveBeenCalledWith(error, 'context');
+    const mockRequest = 1;
+    mutation.mutate(mockRequest);
+    expect(onErrorFn).toHaveBeenCalledWith(error, [mockRequest], 'context');
   });
 });

--- a/query/mutation-types.ts
+++ b/query/mutation-types.ts
@@ -1,14 +1,30 @@
 import { Observable } from 'rxjs';
 
+export type OnMutateFn<Targs extends unknown[], Tcontext> = (
+  args: Targs
+) => Tcontext;
+
+export type OnSuccessFn<Tdata, Targs extends unknown[], Tcontext> = (
+  data: Tdata,
+  args: Targs,
+  context?: Tcontext
+) => void;
+
+export type OnErrorFn<Terror, Targs extends unknown[], Tcontext> = (
+  error: Terror,
+  args: Targs,
+  context?: Tcontext
+) => void;
+
 export interface MutationOptions<
   Tdata,
   Terror,
   Targs extends unknown[],
   Tcontext
 > {
-  onMutate?: (...args: Targs) => Tcontext;
-  onSuccess?: (data: Tdata) => void;
-  onError?: (error: Terror, context?: Tcontext) => void;
+  onMutate?: OnMutateFn<Targs, Tcontext>;
+  onSuccess?: OnSuccessFn<Tdata, Targs, Tcontext>;
+  onError?: OnErrorFn<Terror, Targs, Tcontext>;
 }
 
 export type MutationFn<Tdata, Targs extends unknown[]> = (


### PR DESCRIPTION
Add args and context to mutation callbacks. Breaking change